### PR TITLE
Added MongoDB script to generate MongoDb automatically in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ tls: Config.get('/tlsOptions')
 User may replace their gmail credentials in the .env file for debugging purpose on local environment.
 However, for production the credentials should be set as environment variables.
 
+## MongoDB
+Utilize Docker to install your MongoDB database without needing to install MongoDB driver locally.
 
 ## Technology
 
@@ -131,6 +133,9 @@ $ npm install
 
 # Install webpack-cli globally
 $ npm install webpack-cli -g
+
+# Run the mongo-start generate and start your mongodb using docker 
+$ npm start mongo-start
 
 # Run the node server in development mode
 $ npm start

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "nodemon server.js",
     "dev": "nodemon server.js",
     "prod": "pm2 start pm2.config.js --env production",
-    "test": "mocha"
+    "test": "mocha",
+    "mongo-start": "docker start mongo-dev || docker run --name mongo-dev -p 27017:27017 -d mongo:3.4.23"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This simple docker based js script will help people run mongodb right off the bat starting out. There is no need to install docker locally just run `npm run mongo-start`.  If the docker container does not exist it will create it if it does it will generate it and pull mongodb image. 